### PR TITLE
独自ドメインでAPIに接続できるようにDNSの設定を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,11 @@
-# terraform-boilerplate
-Terraformの設計を行う際に雛形となるプロジェクトです。
-
-このプロジェクトはAWSの管理に特化していますが、他のCloudのResourcesも管理出来るように設計してあります。
-
-## 想定読者
-
-- ある程度Terraformを使った事がある方
-- AWSに関する基礎的なスキルを持っている方
+# kimono-app-terraform
+着物アプリのインフラをTerraformで構築するためのリポジトリ
 
 ## 事前準備
 
 ### 実行環境
 
-tfenvとDockerの利用を紹介します。
-
-どちらの実行環境でもいいですが、Terraformはマイナーバージョンでも破壊的な変更を行う事があるのでバージョンを気軽に切り替えられる事は必須です。
-
-非推奨の機能が次のマイナーバージョンでいきなり削除されることも過去にはあったので、Terraformの警告を無視しない事が非常に大切になります。
+tfenvとDockerの利用を紹介します。どちらを利用してもいいです。
 
 #### tfenv
 
@@ -44,19 +33,11 @@ Docker上でTerraformを実行します。
 
 `docker-compose up -d`
 
-### AWSのIAMユーザーを作成
-
-`AdministratorAccess` を付与したユーザーを作成して下さい。
-
-アクセスキーでアクセス出来るように設定しておく必要があります。
-
-Terraformはこのアクセスキーを使ってAWSの各種Resourcesを作成・管理します。
-
 ### aws_access_key_id, aws_secret_access_keyの設定
 
 Macの場合 `brew install awscli` を実行してaws cliのインストールを行います。
 
-その後、`aws configure --profile nekochans-dev`
+その後、`aws configure --profile kimono-app-stg`
 
 対話形式のインターフェースに従い入力します。
 
@@ -72,30 +53,20 @@ Default output format [None]: json
 `~/.aws/credentials` という名前のファイルを作成して以下の内容を設定します。
 
 ```
-[nekochans-dev]
+[kimono-app-stg]
 aws_access_key_id = あなたのアクセスキーID
 aws_secret_access_key = あなたのシークレットアクセスキー
 ```
 
-このプロジェクトではprofile名を `nekochans-dev` としています。
-
-この名前は任意の物でも構いませんが、必ずprofile名を明示的に付けておく事が重要です。
-
-そうしないと複数のAWS環境を管理する際に誤って他の環境に適応してしまう、等の事故が発生する可能性があるからです。
+このプロジェクトではprofile名を `kimono-app-stg` としています。
 
 profile名を書き換えた場合、`providers/aws/environments/○○/○○/` 配下の `provider.tf`, `backend.tf` を書き換えて下さい。
 
 ### S3Bucketを作成する
 
-`.tfstate` というファイルに実行状態を記録します。（実体はただのJSONファイルです）
+`.tfstate`はS3Bucketに保存します。Terraformを実行する前にS3S3Bucketを作成してください。
 
-このプロジェクトでは `dev-nekochans-tfstate` というS3Bucketがその保存先になります。
-
-この設定は `providers/aws/environments/○○/backend.tf` に記載されています。
-
-S3Bucketはグローバルの名前空間でユニークな名前になっている必要があります。（同じ名前のS3Bucketは作成出来ない）
-
-このプロジェクトを元に設計を行う場合は、この部分を自身が作ったS3Bucketに書き換える必要があります。
+このプロジェクトでは `stg-kimono-app-tfstate` という名前で作成します。
 
 ## ディレクトリ構成
 
@@ -176,32 +147,3 @@ resource "aws_key_pair" "ssh_key_pair" {
 `terraform fmt` は必ずプロジェクトルートで実行を行ってください。
 
 そうしないと全ての `.tf` ファイルに修正が適応されません。
-
-## 参考資料
-
-### [公式ドキュメント](https://www.terraform.io/docs/providers/aws/index.html)
-
-各Resourcesのパラメータ等はここで確認するのが確実です。
-
-### [Terraform Recommended Practices](https://www.terraform.io/docs/enterprise/guides/recommended-practices/index.html)
-
-公式が公開しているベストプラクティス。
-
-設計方針を決める前に一通り見ておく事を推奨します。
-
-### [Terraform Module Registry](https://registry.terraform.io/)
-
-Terraformの開発元である、HashiCorp社が作成したmodule等を見る事が出来る。
-
-基本的にここを参考にすると良いです。
-
-[【モダンTerraform】ベストプラクティスはTerraform Module Registryを参照しよう](http://febc-yamamoto.hatenablog.jp/entry/2018/02/01/090046)
-
-### その他
-
-どの記事も実戦で良く使うテクニックが載っている良記事です。
-
-- [Terraform職人入門: 日々の運用で学んだ知見を淡々とまとめる](https://qiita.com/minamijoyo/items/1f57c62bed781ab8f4d7)
-- [Terraformを1年間運用して学んだトラブルパターン4選](https://medium.com/eureka-engineering/terraform%E3%82%921%E5%B9%B4%E9%96%93%E9%81%8B%E7%94%A8%E3%81%97%E3%81%A6%E5%AD%A6%E3%82%93%E3%81%A0%E3%83%88%E3%83%A9%E3%83%96%E3%83%AB%E3%83%91%E3%82%BF%E3%83%BC%E3%83%B34%E9%81%B8-f31b751a14e6)
-- [Terraform Best Practices in 2017](https://qiita.com/shogomuranushi/items/e2f3ff3cfdcacdd17f99)
-- [同僚に「早く言ってよ〜」と言われたTerraform小技](https://blog.grasys.io/post/kyouhei/tips-of-terraform_target-and-ignore_changes-and-plugin-dir/)

--- a/modules/aws/acm/main.tf
+++ b/modules/aws/acm/main.tf
@@ -1,0 +1,3 @@
+data "aws_acm_certificate" "main" {
+  domain = "*.${var.main_domain_name}"
+}

--- a/modules/aws/acm/outputs.tf
+++ b/modules/aws/acm/outputs.tf
@@ -1,0 +1,3 @@
+output "acm_certificate_arn" {
+  value = data.aws_acm_certificate.main.arn
+}

--- a/modules/aws/acm/variables.tf
+++ b/modules/aws/acm/variables.tf
@@ -1,0 +1,3 @@
+variable "main_domain_name" {
+  type = string
+}

--- a/modules/aws/api/alb.tf
+++ b/modules/aws/api/alb.tf
@@ -36,11 +36,10 @@ resource "aws_alb_target_group" "api" {
 
 resource "aws_alb_listener" "api" {
   load_balancer_arn = aws_alb.api_alb.id
-  // TODO 一時的に80を設定
-  port     = 80
-  protocol = "HTTP"
+  port              = 443
+  protocol          = "HTTPS"
 
-  //  ssl_policy      = "ELBSecurityPolicy-2016-08"
+  ssl_policy      = "ELBSecurityPolicy-2016-08"
   certificate_arn = var.alb_certificate_arn
 
   lifecycle {

--- a/modules/aws/api/route53.tf
+++ b/modules/aws/api/route53.tf
@@ -1,0 +1,11 @@
+resource "aws_route53_record" "api" {
+  zone_id = var.zone_id
+  name    = var.sub_domain_name
+  type    = "A"
+
+  alias {
+    name                   = aws_alb.api_alb.dns_name
+    zone_id                = aws_alb.api_alb.zone_id
+    evaluate_target_health = false
+  }
+}

--- a/modules/aws/api/securitygroup.tf
+++ b/modules/aws/api/securitygroup.tf
@@ -19,11 +19,10 @@ resource "aws_security_group" "alb" {
 resource "aws_security_group_rule" "alb" {
   security_group_id = aws_security_group.alb.id
   type              = "ingress"
-  // TODO 一時的に80を設定
-  from_port   = 80
-  to_port     = 80
-  protocol    = "tcp"
-  cidr_blocks = ["0.0.0.0/0"]
+  from_port         = 443
+  to_port           = 443
+  protocol          = "tcp"
+  cidr_blocks       = ["0.0.0.0/0"]
 }
 
 // ECS

--- a/modules/aws/api/variables.tf
+++ b/modules/aws/api/variables.tf
@@ -10,6 +10,14 @@ variable "subnet_private_ids" {
   type = list(string)
 }
 
+variable "sub_domain_name" {
+  type = string
+}
+
+variable "zone_id" {
+  type = string
+}
+
 variable "sg_alb_name" {
   type = string
 }

--- a/providers/aws/environments/stg/11-acm/backend.tf
+++ b/providers/aws/environments/stg/11-acm/backend.tf
@@ -1,0 +1,9 @@
+terraform {
+  backend "s3" {
+    bucket  = "stg-kimono-app-tfstate"
+    key     = "acm/terraform.tfstate"
+    region  = "ap-northeast-1"
+    profile = "kimono-app-stg"
+  }
+}
+

--- a/providers/aws/environments/stg/11-acm/main.tf
+++ b/providers/aws/environments/stg/11-acm/main.tf
@@ -1,0 +1,15 @@
+module "ap_northeast_1_acm" {
+  source = "../../../../../modules/aws/acm"
+
+  main_domain_name = var.main_domain_name
+}
+
+module "us_east_1_acm" {
+  source = "../../../../../modules/aws/acm"
+
+  main_domain_name = var.main_domain_name
+
+  providers = {
+    aws = aws.us-east-1
+  }
+}

--- a/providers/aws/environments/stg/11-acm/outputs.tf
+++ b/providers/aws/environments/stg/11-acm/outputs.tf
@@ -1,0 +1,7 @@
+output "ap_northeast_1_acm_arn" {
+  value = module.ap_northeast_1_acm.acm_certificate_arn
+}
+
+output "us_east_1_acm_arn" {
+  value = module.us_east_1_acm.acm_certificate_arn
+}

--- a/providers/aws/environments/stg/11-acm/provider.tf
+++ b/providers/aws/environments/stg/11-acm/provider.tf
@@ -1,0 +1,10 @@
+provider "aws" {
+  region  = "ap-northeast-1"
+  profile = "kimono-app-stg"
+}
+
+provider "aws" {
+  region  = "us-east-1"
+  profile = "kimono-app-stg"
+  alias   = "us-east-1"
+}

--- a/providers/aws/environments/stg/11-acm/variables.tf
+++ b/providers/aws/environments/stg/11-acm/variables.tf
@@ -1,0 +1,4 @@
+variable "main_domain_name" {
+  type    = string
+  default = ""
+}

--- a/providers/aws/environments/stg/11-acm/versions.tf
+++ b/providers/aws/environments/stg/11-acm/versions.tf
@@ -1,0 +1,7 @@
+terraform {
+  required_version = "0.12.24"
+
+  required_providers {
+    aws = "2.57.0"
+  }
+}

--- a/providers/aws/environments/stg/20-api/backend.tf
+++ b/providers/aws/environments/stg/20-api/backend.tf
@@ -18,6 +18,17 @@ data "terraform_remote_state" "network" {
   }
 }
 
+data "terraform_remote_state" "acm" {
+  backend = "s3"
+
+  config = {
+    bucket  = "stg-kimono-app-tfstate"
+    key     = "acm/terraform.tfstate"
+    region  = "ap-northeast-1"
+    profile = "kimono-app-stg"
+  }
+}
+
 data "terraform_remote_state" "ecr" {
   backend = "s3"
 

--- a/providers/aws/environments/stg/20-api/main.tf
+++ b/providers/aws/environments/stg/20-api/main.tf
@@ -1,4 +1,4 @@
-module "vpc" {
+module "api" {
   source = "../../../../../modules/aws/api"
 
   subnet_public_ids                = local.subnet_public_ids

--- a/providers/aws/environments/stg/20-api/main.tf
+++ b/providers/aws/environments/stg/20-api/main.tf
@@ -4,6 +4,8 @@ module "api" {
   subnet_public_ids                = local.subnet_public_ids
   subnet_private_ids               = local.subnet_private_ids
   vpc_id                           = local.vpc_id
+  sub_domain_name                  = local.sub_domain_name
+  zone_id                          = data.aws_route53_zone.api.zone_id
   sg_alb_name                      = local.sg_alb_name
   api_alb_name                     = local.api_alb_name
   alblogs_enabled                  = local.alblogs_enabled

--- a/providers/aws/environments/stg/20-api/variables.tf
+++ b/providers/aws/environments/stg/20-api/variables.tf
@@ -2,34 +2,34 @@ locals {
   name = "kimono-app"
   env  = "stg"
 
-  api_alb_name             = "${local.env}-${local.name}-api"
-  sg_alb_name              = "${local.env}-${local.name}-api-alb"
-  alblogs_enabled          = false
-  alb_certificate_arn      = ""
-  ecs_cluster_name         = "${local.env}-${local.name}"
-  ecs_task_definition_name = "${local.env}-${local.name}"
-  ecs_service_name         = "${local.env}-${local.name}"
-  ecs_task_cpu             = 256
-  ecs_task_memory          = 512
-
+  api_alb_name                     = "${local.env}-${local.name}-api"
+  sg_alb_name                      = "${local.env}-${local.name}-api-alb"
+  alblogs_enabled                  = false
+  sub_domain_name                  = "stg-api"
+  ecs_cluster_name                 = "${local.env}-${local.name}"
+  ecs_task_definition_name         = "${local.env}-${local.name}"
+  ecs_service_name                 = "${local.env}-${local.name}"
+  ecs_task_cpu                     = 256
+  ecs_task_memory                  = 512
   sg_ecs_name                      = "${local.env}-${local.name}"
   cloudwatch_log_name              = "${local.env}-${local.name}"
   cloudwatch_log_retention_in_days = 7
 }
 
 locals {
-  vpc_id             = data.terraform_remote_state.network.outputs.vpc_id
-  subnet_public_ids  = data.terraform_remote_state.network.outputs.subnet_public_ids
-  subnet_private_ids = data.terraform_remote_state.network.outputs.subnet_private_ids
-  ecr_api_url        = data.terraform_remote_state.ecr.outputs.ecr_api_url
+  vpc_id              = data.terraform_remote_state.network.outputs.vpc_id
+  subnet_public_ids   = data.terraform_remote_state.network.outputs.subnet_public_ids
+  subnet_private_ids  = data.terraform_remote_state.network.outputs.subnet_private_ids
+  ecr_api_url         = data.terraform_remote_state.ecr.outputs.ecr_api_url
+  alb_certificate_arn = data.terraform_remote_state.acm.outputs.ap_northeast_1_acm_arn
 }
 
-// TODO ドメイン取得後に追加
-//variable "main_domain_name" {
-//  type    = string
-//  default = ""
-//}
-//
-//data "aws_acm_certificate" "main" {
-//  domain = "*.${var.main_domain_name}"
-//}
+variable "main_domain_name" {
+  type    = string
+  default = ""
+}
+
+data "aws_route53_zone" "api" {
+  name = var.main_domain_name
+}
+


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/kimono-app-terraform/issues/2

# Doneの定義
APIに独自ドメインでHTTPS接続できること

# 変更点概要

## 技術的変更点概要
ドメインを購入し、APIにHTTPSで接続できるように変更した。

- AWSコンソールから下記を行なった
  - ドメインの購入
  - AMC証明書(`ap-northeast-1`と`us-east-1`に追加)
  CloudFrontでACMを利用することを想定し、`us-east-1`にも作成している

- `modules/aws/acm` を追加
`ap-northeast-1`と`us-east-1`のリージョンから、それぞれの`data.aws_acm_certificate.main.arn`を取得できるようにした

- READMEがテンプレートのままだったので着物アプリ用に更新
プロジェクトに関係のない部分は削除している

# 補足情報
[ACM Supported Regions](https://docs.aws.amazon.com/acm/latest/userguide/acm-regions.html)
> To use an ACM certificate with Amazon CloudFront, you must request or import the certificate in the US East (N. Virginia) region. 