### PR TITLE
Cognitoユーザープール用のリソースを作成する

### DIFF
--- a/modules/aws/cognito/main.tf
+++ b/modules/aws/cognito/main.tf
@@ -1,0 +1,37 @@
+resource "aws_cognito_user_pool" "pool" {
+  name                     = var.user_pool_name
+  auto_verified_attributes = ["email"]
+
+  admin_create_user_config {
+    allow_admin_create_user_only = false
+  }
+
+  password_policy {
+    minimum_length                   = 8
+    require_lowercase                = true
+    require_numbers                  = true
+    require_symbols                  = true
+    require_uppercase                = true
+    temporary_password_validity_days = 7
+  }
+
+  verification_message_template {
+    default_email_option = "CONFIRM_WITH_CODE"
+    email_message        = "検証コードは {####} です。"
+    email_subject        = "検証コード"
+    sms_message          = "検証コードは {####} です。"
+  }
+
+  schema {
+    attribute_data_type      = "String"
+    developer_only_attribute = false
+    mutable                  = true
+    name                     = "email"
+    required                 = true
+
+    string_attribute_constraints {
+      min_length = 0
+      max_length = 2048
+    }
+  }
+}

--- a/modules/aws/cognito/main.tf
+++ b/modules/aws/cognito/main.tf
@@ -35,3 +35,12 @@ resource "aws_cognito_user_pool" "pool" {
     }
   }
 }
+
+resource "aws_cognito_user_pool_client" "client" {
+  name                          = var.user_pool_name
+  user_pool_id                  = aws_cognito_user_pool.pool.id
+  generate_secret               = false
+  prevent_user_existence_errors = "ENABLED"
+  refresh_token_validity        = 30
+  explicit_auth_flows           = ["ALLOW_ADMIN_USER_PASSWORD_AUTH", "ALLOW_REFRESH_TOKEN_AUTH"]
+}

--- a/modules/aws/cognito/variables.tf
+++ b/modules/aws/cognito/variables.tf
@@ -1,0 +1,3 @@
+variable "user_pool_name" {
+  type = string
+}

--- a/providers/aws/environments/stg/13-cognito/backend.tf
+++ b/providers/aws/environments/stg/13-cognito/backend.tf
@@ -1,0 +1,9 @@
+terraform {
+  backend "s3" {
+    bucket  = "stg-kimono-app-tfstate"
+    key     = "cognito/terraform.tfstate"
+    region  = "ap-northeast-1"
+    profile = "kimono-app-stg"
+  }
+}
+

--- a/providers/aws/environments/stg/13-cognito/main.tf
+++ b/providers/aws/environments/stg/13-cognito/main.tf
@@ -1,0 +1,5 @@
+module "api" {
+  source = "../../../../../modules/aws/cognito"
+
+  user_pool_name = local.user_pool_name
+}

--- a/providers/aws/environments/stg/13-cognito/provider.tf
+++ b/providers/aws/environments/stg/13-cognito/provider.tf
@@ -1,0 +1,4 @@
+provider "aws" {
+  region  = "ap-northeast-1"
+  profile = "kimono-app-stg"
+}

--- a/providers/aws/environments/stg/13-cognito/variables.tf
+++ b/providers/aws/environments/stg/13-cognito/variables.tf
@@ -1,0 +1,6 @@
+locals {
+  name = "kimono-app"
+  env  = "stg"
+
+  user_pool_name = "${local.env}-${local.name}"
+}

--- a/providers/aws/environments/stg/13-cognito/versions.tf
+++ b/providers/aws/environments/stg/13-cognito/versions.tf
@@ -1,0 +1,7 @@
+terraform {
+  required_version = "0.12.24"
+
+  required_providers {
+    aws = "2.57.0"
+  }
+}


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/kimono-app-terraform/issues/3

# Doneの定義
- Cognitoユーザープールが作成されていること

Issueではステージング用とローカル環境用の2種類を用意する想定であったが、現時点では2種類を用意する必要はないため1つだけ作成する。

# 変更点概要

## 技術的変更点概要
Cognito User Pool とアプリクライアントを作成。
Emailを必須項目とし、ユーザ名とパスワードでログインすることを想定している。

SESの設定は別のPRとする。

User Poolの下記の設定はTerraformでは対応していないため、一旦非推奨の設定になっている。
<img width="1128" alt="スクリーンショット 2020-06-03 23 54 58" src="https://user-images.githubusercontent.com/32682645/83652542-b5917200-a5f5-11ea-9e29-aca3cdec7afe.png">

terraform-provider-aws に Issueは作成されているが、いつ対応されるかは不明。
https://github.com/terraform-providers/terraform-provider-aws/issues/11220

下記のように local-exec を使用することで設定するか、もしくはこの設定だけ手動で設定するかを検討する必要がある。これについては課題を作成して、別途対応としたい。
https://stackoverflow.com/questions/59120055/set-account-recovery-preference-for-aws-cognito-user-pool-with-terraform