### PR TITLE
ユーザがパスワードでログインできるようにCognitoのexplicit_auth_flowsを変更

### DIFF
--- a/modules/aws/cognito/main.tf
+++ b/modules/aws/cognito/main.tf
@@ -47,5 +47,5 @@ resource "aws_cognito_user_pool_client" "client" {
   generate_secret               = false
   prevent_user_existence_errors = "ENABLED"
   refresh_token_validity        = 30
-  explicit_auth_flows           = ["ALLOW_ADMIN_USER_PASSWORD_AUTH", "ALLOW_REFRESH_TOKEN_AUTH"]
+  explicit_auth_flows           = ["ALLOW_USER_PASSWORD_AUTH", "ALLOW_ADMIN_USER_PASSWORD_AUTH", "ALLOW_REFRESH_TOKEN_AUTH"]
 }


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/kimono-app-terraform/issues/10

# Doneの定義
https://github.com/nekochans/kimono-app-terraform/issues/10 の完了の定義が満たされていること

# 変更点概要

## 技術的変更点概要
Issueの補足に書いた通りだが、ユーザ名とパスワードでログインする際に、下記のエラーが発生した。
開発を進めるために、explicit_auth_flowsにALLOW_USER_PASSWORD_AUTHを追加する。
```
USER_PASSWORD_AUTH flow not enabled for this client
```

フロントエンドからユーザ名とパスワードでログイン出来ることを確認済み。
# 補足情報
フロントエンドの関連PR: https://github.com/nekochans/kimono-app-frontend/pull/19
