### PR TITLE
TerraformのバリデーションをCIで実行出来るように設定

### DIFF
--- a/.github/workflows/ci-master.yml
+++ b/.github/workflows/ci-master.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Setup Terraform
       uses: hashicorp/setup-terraform@v1
       with:
-        terraform_version: 0.12.25
+        terraform_version: 0.12.24
 
     - name: Terraform Format
       run: terraform fmt -recursive -check

--- a/.github/workflows/ci-master.yml
+++ b/.github/workflows/ci-master.yml
@@ -1,0 +1,27 @@
+name: ci-master
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  terraform:
+    name: Terraform
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        shell: bash
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Setup Terraform
+      uses: hashicorp/setup-terraform@v1
+      with:
+        terraform_version: 0.12.25
+
+    - name: Terraform Format
+      run: terraform fmt -recursive -check

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # kimono-app-terraform
+
+![ci-master](https://github.com/nekochans/kimono-app-terraform/workflows/ci-master/badge.svg)
+
 着物アプリのインフラをTerraformで構築するためのリポジトリ
 
 ## 事前準備


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/kimono-app-terraform/issues/9

# Doneの定義
- `terraform fmt` で差分があった場合はCIが失敗するように改修されている事

# 変更点概要

## 技術的変更点概要
- GitHubActionsで `terraform fmt -recursive -check` を実行する為に必要な設定を追加

公式の https://github.com/hashicorp/setup-terraform を利用。

# レビュアーに重点的にチェックして欲しい点
@kobayashi-m42 口頭で話した通り、`terraform apply` や `terraform plan` に関しては、かなり強い権限を持ったAWSのアクセスキーが必要だったり、そもそも `apply` を自動でやっていいの？って点がまだ決まってないから、最低限 `terraform fmt` がかかっているか確認するだけにしてあるよ！:cat2: 