### PR TITLE
API Gatewayを追加

### DIFF
--- a/modules/aws/apigateway/main.tf
+++ b/modules/aws/apigateway/main.tf
@@ -1,0 +1,24 @@
+resource "aws_apigatewayv2_api" "apigateway" {
+  name          = var.apigateway_name
+  protocol_type = "HTTP"
+}
+
+resource "aws_apigatewayv2_stage" "apigateway" {
+  api_id      = aws_apigatewayv2_api.apigateway.id
+  name        = "$default"
+  auto_deploy = var.auto_deploy
+}
+
+resource "aws_apigatewayv2_route" "apigateway" {
+  api_id    = aws_apigatewayv2_api.apigateway.id
+  route_key = "$default"
+  target    = "integrations/${aws_apigatewayv2_integration.apigateway.id}"
+}
+
+
+resource "aws_apigatewayv2_integration" "apigateway" {
+  api_id             = aws_apigatewayv2_api.apigateway.id
+  integration_type   = "HTTP_PROXY"
+  integration_method = "ANY"
+  integration_uri    = var.integration_uri
+}

--- a/modules/aws/apigateway/main.tf
+++ b/modules/aws/apigateway/main.tf
@@ -5,7 +5,7 @@ resource "aws_apigatewayv2_api" "apigateway" {
 
 resource "aws_apigatewayv2_stage" "apigateway" {
   api_id      = aws_apigatewayv2_api.apigateway.id
-  name        = "$default"
+  name        = var.apigateway_stage
   auto_deploy = var.auto_deploy
 }
 

--- a/modules/aws/apigateway/main.tf
+++ b/modules/aws/apigateway/main.tf
@@ -22,3 +22,19 @@ resource "aws_apigatewayv2_integration" "apigateway" {
   integration_method = "ANY"
   integration_uri    = var.integration_uri
 }
+
+resource "aws_apigatewayv2_domain_name" "apigateway" {
+  domain_name = var.apigateway_domain_name
+
+  domain_name_configuration {
+    certificate_arn = var.certificate_arn
+    endpoint_type   = "REGIONAL"
+    security_policy = "TLS_1_2"
+  }
+}
+
+resource "aws_apigatewayv2_api_mapping" "apigateway" {
+  api_id      = aws_apigatewayv2_api.apigateway.id
+  stage       = aws_apigatewayv2_stage.apigateway.id
+  domain_name = aws_apigatewayv2_domain_name.apigateway.domain_name
+}

--- a/modules/aws/apigateway/route53.tf
+++ b/modules/aws/apigateway/route53.tf
@@ -1,0 +1,11 @@
+resource "aws_route53_record" "apigateway" {
+  zone_id = var.zone_id
+  name    = aws_apigatewayv2_domain_name.apigateway.domain_name
+  type    = "A"
+
+  alias {
+    name                   = aws_apigatewayv2_domain_name.apigateway.domain_name_configuration.0.target_domain_name
+    zone_id                = aws_apigatewayv2_domain_name.apigateway.domain_name_configuration.0.hosted_zone_id
+    evaluate_target_health = false
+  }
+}

--- a/modules/aws/apigateway/variables.tf
+++ b/modules/aws/apigateway/variables.tf
@@ -9,3 +9,15 @@ variable "auto_deploy" {
 variable "integration_uri" {
   type = string
 }
+
+variable "certificate_arn" {
+  type = string
+}
+
+variable "zone_id" {
+  type = string
+}
+
+variable "apigateway_domain_name" {
+  type = string
+}

--- a/modules/aws/apigateway/variables.tf
+++ b/modules/aws/apigateway/variables.tf
@@ -2,6 +2,10 @@ variable "apigateway_name" {
   type = string
 }
 
+variable "apigateway_stage" {
+  type = string
+}
+
 variable "auto_deploy" {
   type = bool
 }

--- a/modules/aws/apigateway/variables.tf
+++ b/modules/aws/apigateway/variables.tf
@@ -1,0 +1,11 @@
+variable "apigateway_name" {
+  type = string
+}
+
+variable "auto_deploy" {
+  type = bool
+}
+
+variable "integration_uri" {
+  type = string
+}

--- a/providers/aws/environments/stg/10-network/versions.tf
+++ b/providers/aws/environments/stg/10-network/versions.tf
@@ -2,6 +2,6 @@ terraform {
   required_version = "0.12.24"
 
   required_providers {
-    aws = "2.57.0"
+    aws = "2.70.0"
   }
 }

--- a/providers/aws/environments/stg/11-acm/versions.tf
+++ b/providers/aws/environments/stg/11-acm/versions.tf
@@ -2,6 +2,6 @@ terraform {
   required_version = "0.12.24"
 
   required_providers {
-    aws = "2.57.0"
+    aws = "2.70.0"
   }
 }

--- a/providers/aws/environments/stg/12-ecr/versions.tf
+++ b/providers/aws/environments/stg/12-ecr/versions.tf
@@ -2,6 +2,6 @@ terraform {
   required_version = "0.12.24"
 
   required_providers {
-    aws = "2.57.0"
+    aws = "2.70.0"
   }
 }

--- a/providers/aws/environments/stg/13-ses/versions.tf
+++ b/providers/aws/environments/stg/13-ses/versions.tf
@@ -2,6 +2,6 @@ terraform {
   required_version = "0.12.24"
 
   required_providers {
-    aws = "2.57.0"
+    aws = "2.70.0"
   }
 }

--- a/providers/aws/environments/stg/14-cognito/versions.tf
+++ b/providers/aws/environments/stg/14-cognito/versions.tf
@@ -2,6 +2,6 @@ terraform {
   required_version = "0.12.24"
 
   required_providers {
-    aws = "2.57.0"
+    aws = "2.70.0"
   }
 }

--- a/providers/aws/environments/stg/20-api/main.tf
+++ b/providers/aws/environments/stg/20-api/main.tf
@@ -25,6 +25,7 @@ module "apigateway" {
   source = "../../../../../modules/aws/apigateway"
 
   apigateway_name        = local.apigateway_name
+  apigateway_stage       = local.apigateway_stage
   auto_deploy            = local.auto_deploy
   integration_uri        = local.integration_uri
   apigateway_domain_name = local.apigateway_domain_name

--- a/providers/aws/environments/stg/20-api/main.tf
+++ b/providers/aws/environments/stg/20-api/main.tf
@@ -20,3 +20,11 @@ module "api" {
   cloudwatch_log_name              = local.cloudwatch_log_name
   cloudwatch_log_retention_in_days = local.cloudwatch_log_retention_in_days
 }
+
+module "apigateway" {
+  source = "../../../../../modules/aws/apigateway"
+
+  apigateway_name = local.apigateway_name
+  auto_deploy     = local.auto_deploy
+  integration_uri = local.integration_uri
+}

--- a/providers/aws/environments/stg/20-api/main.tf
+++ b/providers/aws/environments/stg/20-api/main.tf
@@ -24,7 +24,10 @@ module "api" {
 module "apigateway" {
   source = "../../../../../modules/aws/apigateway"
 
-  apigateway_name = local.apigateway_name
-  auto_deploy     = local.auto_deploy
-  integration_uri = local.integration_uri
+  apigateway_name        = local.apigateway_name
+  auto_deploy            = local.auto_deploy
+  integration_uri        = local.integration_uri
+  apigateway_domain_name = local.apigateway_domain_name
+  certificate_arn        = local.alb_certificate_arn
+  zone_id                = data.aws_route53_zone.api.zone_id
 }

--- a/providers/aws/environments/stg/20-api/variables.tf
+++ b/providers/aws/environments/stg/20-api/variables.tf
@@ -24,6 +24,12 @@ locals {
   alb_certificate_arn = data.terraform_remote_state.acm.outputs.ap_northeast_1_acm_arn
 }
 
+locals {
+  apigateway_name = "${local.env}-${local.name}-api"
+  auto_deploy     = true
+  integration_uri = "https://${local.sub_domain_name}.${var.main_domain_name}"
+}
+
 variable "main_domain_name" {
   type    = string
   default = ""

--- a/providers/aws/environments/stg/20-api/variables.tf
+++ b/providers/aws/environments/stg/20-api/variables.tf
@@ -29,6 +29,7 @@ locals {
   auto_deploy            = true
   integration_uri        = "https://${local.sub_domain_name}.${var.main_domain_name}"
   apigateway_domain_name = "stg-apigateway.${var.main_domain_name}"
+  apigateway_stage       = "$default"
 }
 
 variable "main_domain_name" {

--- a/providers/aws/environments/stg/20-api/variables.tf
+++ b/providers/aws/environments/stg/20-api/variables.tf
@@ -25,9 +25,10 @@ locals {
 }
 
 locals {
-  apigateway_name = "${local.env}-${local.name}-api"
-  auto_deploy     = true
-  integration_uri = "https://${local.sub_domain_name}.${var.main_domain_name}"
+  apigateway_name        = "${local.env}-${local.name}-api"
+  auto_deploy            = true
+  integration_uri        = "https://${local.sub_domain_name}.${var.main_domain_name}"
+  apigateway_domain_name = "stg-apigateway.${var.main_domain_name}"
 }
 
 variable "main_domain_name" {

--- a/providers/aws/environments/stg/20-api/versions.tf
+++ b/providers/aws/environments/stg/20-api/versions.tf
@@ -2,6 +2,6 @@ terraform {
   required_version = "0.12.24"
 
   required_providers {
-    aws = "2.57.0"
+    aws = "2.70.0"
   }
 }


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/kimono-app-terraform/issues/13

# Doneの定義
https://github.com/nekochans/kimono-app-terraform/issues/13 の完了の定義が満たされていること

# 変更点概要

## 仕様的変更点概要
API Gateway経由でバックエンドAPIにリクエストできるように修正。

## 技術的変更点概要
- AWS Providerを現時点の最新バーション`2.70.0`に更新
以前のバージョンでは、API Gateway(HTTP API)に対応していなかったため。
`providers/aws/environments/stg`配下のディレクトリで指定しているバーションを全てアップデートした。

- API Gatewayを作成
  - API タイプは、HTTP APIを指定
HTTP APIはInternal ALBに対応しているためHTTP APIを指定。
将来的にk8sを利用した際にALBと連携できるように、という点を考慮した。

  - 統合には、バックエンドAPIのURL endpointを指定。
ECSのバックエンドAPIに設定しているALBがパブリックのため。https://github.com/nekochans/kimono-app-terraform/issues/16 の対応でprivate ALBに変更した際に、統合先を変更する。

  - Default RouteとDefault Stageを設定
今後変更するかもしれないが、現時点ではdefaultを指定した。
参考: https://dev.classmethod.jp/articles/amazon-api-gateway-http-or-rest/#toc-6

  - 自動デプロイを有効化
  - カスタムドメインを設定

# 補足情報
API GatewayのドメインはSlackで連絡済み。
