### PR TITLE
APIGateway経由で呼び出す際にCognitoのトークンを必須にする

### DIFF
--- a/modules/aws/apigateway/main.tf
+++ b/modules/aws/apigateway/main.tf
@@ -10,17 +10,30 @@ resource "aws_apigatewayv2_stage" "apigateway" {
 }
 
 resource "aws_apigatewayv2_route" "apigateway" {
-  api_id    = aws_apigatewayv2_api.apigateway.id
-  route_key = "$default"
-  target    = "integrations/${aws_apigatewayv2_integration.apigateway.id}"
+  api_id             = aws_apigatewayv2_api.apigateway.id
+  route_key          = "$default"
+  target             = "integrations/${aws_apigatewayv2_integration.apigateway.id}"
+  authorization_type = "JWT"
+  authorizer_id      = aws_apigatewayv2_authorizer.apigateway.id
 }
-
 
 resource "aws_apigatewayv2_integration" "apigateway" {
   api_id             = aws_apigatewayv2_api.apigateway.id
   integration_type   = "HTTP_PROXY"
   integration_method = "ANY"
   integration_uri    = var.integration_uri
+}
+
+resource "aws_apigatewayv2_authorizer" "apigateway" {
+  api_id           = aws_apigatewayv2_api.apigateway.id
+  authorizer_type  = "JWT"
+  identity_sources = ["$request.header.Authorization"]
+  name             = "cognito"
+
+  jwt_configuration {
+    audience = var.authorizer_audience
+    issuer   = var.cognito_user_pool_endpoint
+  }
 }
 
 resource "aws_apigatewayv2_domain_name" "apigateway" {

--- a/modules/aws/apigateway/variables.tf
+++ b/modules/aws/apigateway/variables.tf
@@ -6,6 +6,14 @@ variable "apigateway_stage" {
   type = string
 }
 
+variable "authorizer_audience" {
+  type = list(string)
+}
+
+variable "cognito_user_pool_endpoint" {
+  type = string
+}
+
 variable "auto_deploy" {
   type = bool
 }

--- a/modules/aws/cognito/outputs.tf
+++ b/modules/aws/cognito/outputs.tf
@@ -1,0 +1,3 @@
+output "cognito_user_pool_endpoint" {
+  value = aws_cognito_user_pool.pool.endpoint
+}

--- a/providers/aws/environments/stg/14-cognito/outputs.tf
+++ b/providers/aws/environments/stg/14-cognito/outputs.tf
@@ -1,0 +1,3 @@
+output "cognito_user_pool_endpoint" {
+  value = module.api.cognito_user_pool_endpoint
+}

--- a/providers/aws/environments/stg/20-api/backend.tf
+++ b/providers/aws/environments/stg/20-api/backend.tf
@@ -39,3 +39,14 @@ data "terraform_remote_state" "ecr" {
     profile = "kimono-app-stg"
   }
 }
+
+data "terraform_remote_state" "cognito" {
+  backend = "s3"
+
+  config = {
+    bucket  = "stg-kimono-app-tfstate"
+    key     = "cognito/terraform.tfstate"
+    region  = "ap-northeast-1"
+    profile = "kimono-app-stg"
+  }
+}

--- a/providers/aws/environments/stg/20-api/main.tf
+++ b/providers/aws/environments/stg/20-api/main.tf
@@ -24,11 +24,13 @@ module "api" {
 module "apigateway" {
   source = "../../../../../modules/aws/apigateway"
 
-  apigateway_name        = local.apigateway_name
-  apigateway_stage       = local.apigateway_stage
-  auto_deploy            = local.auto_deploy
-  integration_uri        = local.integration_uri
-  apigateway_domain_name = local.apigateway_domain_name
-  certificate_arn        = local.alb_certificate_arn
-  zone_id                = data.aws_route53_zone.api.zone_id
+  apigateway_name            = local.apigateway_name
+  apigateway_stage           = local.apigateway_stage
+  authorizer_audience        = local.authorizer_audience
+  cognito_user_pool_endpoint = local.cognito_user_pool_endpoint
+  auto_deploy                = local.auto_deploy
+  integration_uri            = local.integration_uri
+  apigateway_domain_name     = local.apigateway_domain_name
+  certificate_arn            = local.alb_certificate_arn
+  zone_id                    = data.aws_route53_zone.api.zone_id
 }

--- a/providers/aws/environments/stg/20-api/variables.tf
+++ b/providers/aws/environments/stg/20-api/variables.tf
@@ -25,14 +25,21 @@ locals {
 }
 
 locals {
-  apigateway_name        = "${local.env}-${local.name}-api"
-  auto_deploy            = true
-  integration_uri        = "https://${local.sub_domain_name}.${var.main_domain_name}"
-  apigateway_domain_name = "stg-apigateway.${var.main_domain_name}"
-  apigateway_stage       = "$default"
+  apigateway_name            = "${local.env}-${local.name}-api"
+  auto_deploy                = true
+  integration_uri            = "https://${local.sub_domain_name}.${var.main_domain_name}"
+  apigateway_domain_name     = "stg-apigateway.${var.main_domain_name}"
+  apigateway_stage           = "$default"
+  authorizer_audience        = [var.cognito_user_pool_client_id]
+  cognito_user_pool_endpoint = "https://${data.terraform_remote_state.cognito.outputs.cognito_user_pool_endpoint}"
 }
 
 variable "main_domain_name" {
+  type    = string
+  default = ""
+}
+
+variable "cognito_user_pool_client_id" {
   type    = string
   default = ""
 }


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/kimono-app-terraform/issues/14

# Doneの定義
https://github.com/nekochans/kimono-app-terraform/issues/14  の完了の定義が満たされていること

# 変更点概要

## 仕様的変更点概要
API Gateway経由でECSのAPIを呼び出す際に、CognitoのIDトークンを必須に変更
IDトークンがない場合401を返す

## 技術的変更点概要
API GatewayにJWTオーサライザーを追加。
認証プロバイダにはCognitoを指定している。

- ID トークンあり場合のレスポンス
```
< HTTP/2 200
< date: Thu, 30 Jul 2020 16:56:22 GMT
< content-type: text/plain; charset=utf-8
< content-length: 20
< apigw-requestid: QfxEfjACtjMEM5A=
<
* Connection #0 to host stg-apigateway.xxxx.xx left intact
Hello, HTTPサーバ
```


- ID トークンがない場合のレスポンス
```
< HTTP/2 401
< date: Thu, 30 Jul 2020 16:56:29 GMT
< content-length: 26
< www-authenticate: Bearer scope="" error="invalid_token" error_description="crypto/rsa: verification error"
< apigw-requestid: QfxFojRANjMENbw=
<
* Connection #0 to host stg-apigateway.xxxx.xx left intact
{"message":"Unauthorized"}
```