### PR TITLE
cognitoにリソースサーバーとスコープを追加する

### DIFF
--- a/modules/aws/cognito/main.tf
+++ b/modules/aws/cognito/main.tf
@@ -48,4 +48,32 @@ resource "aws_cognito_user_pool_client" "client" {
   prevent_user_existence_errors = "ENABLED"
   refresh_token_validity        = 30
   explicit_auth_flows           = ["ALLOW_USER_PASSWORD_AUTH", "ALLOW_ADMIN_USER_PASSWORD_AUTH", "ALLOW_REFRESH_TOKEN_AUTH"]
+
+  allowed_oauth_flows_user_pool_client = true
+  allowed_oauth_scopes                 = var.allowed_oauth_scopes
+  callback_urls                        = var.callback_urls
+  supported_identity_providers         = ["COGNITO"]
+  allowed_oauth_flows                  = ["code"]
+
+}
+
+resource "aws_cognito_resource_server" "resource" {
+  identifier = var.resource_server_identifier
+  name       = var.resource_server_name
+
+  scope {
+    scope_name        = "admin"
+    scope_description = "for administrator"
+  }
+  scope {
+    scope_name        = "normal"
+    scope_description = "for normal user"
+  }
+
+  user_pool_id = aws_cognito_user_pool.pool.id
+}
+
+resource "aws_cognito_user_pool_domain" "domain" {
+  domain       = var.user_pool_domain
+  user_pool_id = aws_cognito_user_pool.pool.id
 }

--- a/modules/aws/cognito/variables.tf
+++ b/modules/aws/cognito/variables.tf
@@ -2,6 +2,26 @@ variable "user_pool_name" {
   type = string
 }
 
+variable "user_pool_domain" {
+  type = string
+}
+
+variable "resource_server_name" {
+  type = string
+}
+
+variable "resource_server_identifier" {
+  type = string
+}
+
 variable "ses_email_identity_arn" {
   type = string
+}
+
+variable "allowed_oauth_scopes" {
+  type = list(string)
+}
+
+variable "callback_urls" {
+  type = list(string)
 }

--- a/providers/aws/environments/stg/14-cognito/main.tf
+++ b/providers/aws/environments/stg/14-cognito/main.tf
@@ -1,6 +1,11 @@
 module "api" {
   source = "../../../../../modules/aws/cognito"
 
-  user_pool_name         = local.user_pool_name
-  ses_email_identity_arn = data.terraform_remote_state.ses.outputs.ses_email_identity_arn
+  user_pool_name             = local.user_pool_name
+  user_pool_domain           = local.user_pool_domain
+  resource_server_name       = local.resource_server_name
+  resource_server_identifier = local.resource_server_identifier
+  ses_email_identity_arn     = data.terraform_remote_state.ses.outputs.ses_email_identity_arn
+  allowed_oauth_scopes       = local.allowed_oauth_scopes
+  callback_urls              = local.callback_urls
 }

--- a/providers/aws/environments/stg/14-cognito/variables.tf
+++ b/providers/aws/environments/stg/14-cognito/variables.tf
@@ -2,5 +2,10 @@ locals {
   name = "kimono-app"
   env  = "stg"
 
-  user_pool_name = "${local.env}-${local.name}"
+  user_pool_name             = "${local.env}-${local.name}"
+  user_pool_domain           = "${local.env}-${local.name}"
+  resource_server_name       = "${local.env}-${local.name}"
+  resource_server_identifier = "${local.env}-${local.name}"
+  allowed_oauth_scopes       = ["openid", "stg-kimono-app/admin", "stg-kimono-app/normal"]
+  callback_urls              = ["http://localhost:3000"]
 }


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/kimono-app-terraform/issues/23

# Doneの定義
https://github.com/nekochans/kimono-app-terraform/issues/23 の完了の定義が満たされていること

# 変更点概要

## 技術的変更点概要
cognitoにカスタムサーバーを構築し、カスタムスコープ を設定。

リソースサーバーを設定しただけでは、アクセストークンにカスタムスコープを追加することができなかったので、下記についても合わせて修正を行った。
- アプリクライアントに有効なプロバイダーとしてユーザープールを指定
- ユーザープールにドメインを設定

[AmplifyでCognitoのHosted UIを利用した認証を最低限の実装で動かしてみて動作を理解する](https://dev.classmethod.jp/articles/learn-authentication-using-cognitos-hosted-ui-with-amplify/#toc-12)を参考に、Authorization code grantフローでユーザプールに登録済みのユーザでログインし、アクセストークン(カスタムスコープ を含む)を取得できることを確認済み。