### PR TITLE
バックエンドのAPIのALBをprivateにする

### DIFF
--- a/modules/aws/api/ecs.tf
+++ b/modules/aws/api/ecs.tf
@@ -37,6 +37,12 @@ resource "aws_ecs_service" "api_fargate_service" {
     container_port   = 8888
   }
 
+  load_balancer {
+    target_group_arn = aws_alb_target_group.internal.id
+    container_name   = "go"
+    container_port   = 8888
+  }
+
   network_configuration {
     subnets = var.subnet_private_ids
 

--- a/modules/aws/api/outputs.tf
+++ b/modules/aws/api/outputs.tf
@@ -1,0 +1,7 @@
+output "sg_internal_alb_id" {
+  value = aws_security_group.internal_alb.id
+}
+
+output "internal_alb_listener_arn" {
+  value = aws_alb_listener.internal.arn
+}

--- a/modules/aws/api/securitygroup.tf
+++ b/modules/aws/api/securitygroup.tf
@@ -25,6 +25,24 @@ resource "aws_security_group_rule" "alb" {
   cidr_blocks       = ["0.0.0.0/0"]
 }
 
+// internal ALB
+resource "aws_security_group" "internal_alb" {
+  name        = var.sg_internal_alb_name
+  description = "Security Group to ${var.sg_internal_alb_name}"
+  vpc_id      = var.vpc_id
+
+  tags = {
+    Name = var.sg_internal_alb_name
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
 // ECS
 resource "aws_security_group" "ecs" {
   name        = var.sg_ecs_name
@@ -50,4 +68,13 @@ resource "aws_security_group_rule" "ecs_from_alb" {
   to_port                  = 8888
   protocol                 = "tcp"
   source_security_group_id = aws_security_group.alb.id
+}
+
+resource "aws_security_group_rule" "ecs_from_internal_alb" {
+  security_group_id        = aws_security_group.ecs.id
+  type                     = "ingress"
+  from_port                = 8888
+  to_port                  = 8888
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.internal_alb.id
 }

--- a/modules/aws/api/variables.tf
+++ b/modules/aws/api/variables.tf
@@ -22,7 +22,15 @@ variable "sg_alb_name" {
   type = string
 }
 
+variable "sg_internal_alb_name" {
+  type = string
+}
+
 variable "api_alb_name" {
+  type = string
+}
+
+variable "api_internal_alb_name" {
   type = string
 }
 

--- a/modules/aws/apigateway/main.tf
+++ b/modules/aws/apigateway/main.tf
@@ -12,16 +12,19 @@ resource "aws_apigatewayv2_stage" "apigateway" {
 resource "aws_apigatewayv2_route" "apigateway" {
   api_id             = aws_apigatewayv2_api.apigateway.id
   route_key          = "$default"
-  target             = "integrations/${aws_apigatewayv2_integration.apigateway.id}"
+  target             = "integrations/${aws_apigatewayv2_integration.vpclink.id}"
   authorization_type = "JWT"
   authorizer_id      = aws_apigatewayv2_authorizer.apigateway.id
 }
 
-resource "aws_apigatewayv2_integration" "apigateway" {
-  api_id             = aws_apigatewayv2_api.apigateway.id
+resource "aws_apigatewayv2_integration" "vpclink" {
+  api_id = aws_apigatewayv2_api.apigateway.id
+
+  connection_type    = "VPC_LINK"
+  connection_id      = aws_apigatewayv2_vpc_link.vpilink.id
   integration_type   = "HTTP_PROXY"
   integration_method = "ANY"
-  integration_uri    = var.integration_uri
+  integration_uri    = var.internal_alb_listener_arn
 }
 
 resource "aws_apigatewayv2_authorizer" "apigateway" {

--- a/modules/aws/apigateway/sg.tf
+++ b/modules/aws/apigateway/sg.tf
@@ -1,0 +1,25 @@
+resource "aws_security_group" "vpclink" {
+  name        = var.sg_vpc_link_name
+  description = "Security Group to ${var.sg_vpc_link_name}"
+  vpc_id      = var.vpc_id
+
+  tags = {
+    Name = var.sg_vpc_link_name
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+resource "aws_security_group_rule" "internal_alb" {
+  security_group_id        = var.sg_internal_alb_id
+  type                     = "ingress"
+  from_port                = 80
+  to_port                  = 80
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.vpclink.id
+}

--- a/modules/aws/apigateway/variables.tf
+++ b/modules/aws/apigateway/variables.tf
@@ -1,3 +1,19 @@
+variable "vpc_id" {
+  type = string
+}
+
+variable "subnet_private_ids" {
+  type = list(string)
+}
+
+variable "vpc_link_name" {
+  type = string
+}
+
+variable "sg_vpc_link_name" {
+  type = string
+}
+
 variable "apigateway_name" {
   type = string
 }
@@ -31,5 +47,13 @@ variable "zone_id" {
 }
 
 variable "apigateway_domain_name" {
+  type = string
+}
+
+variable "sg_internal_alb_id" {
+  type = string
+}
+
+variable "internal_alb_listener_arn" {
   type = string
 }

--- a/modules/aws/apigateway/vpclink.tf
+++ b/modules/aws/apigateway/vpclink.tf
@@ -1,0 +1,9 @@
+resource "aws_apigatewayv2_vpc_link" "vpilink" {
+  name               = var.vpc_link_name
+  security_group_ids = [aws_security_group.vpclink.id]
+  subnet_ids         = var.subnet_private_ids
+
+  tags = {
+    Usage = var.vpc_link_name
+  }
+}

--- a/providers/aws/environments/stg/20-api/main.tf
+++ b/providers/aws/environments/stg/20-api/main.tf
@@ -8,6 +8,8 @@ module "api" {
   zone_id                          = data.aws_route53_zone.api.zone_id
   sg_alb_name                      = local.sg_alb_name
   api_alb_name                     = local.api_alb_name
+  sg_internal_alb_name             = local.sg_internal_alb_name
+  api_internal_alb_name            = local.api_internal_alb_name
   alblogs_enabled                  = local.alblogs_enabled
   alb_certificate_arn              = local.alb_certificate_arn
   ecs_cluster_name                 = local.ecs_cluster_name
@@ -24,6 +26,10 @@ module "api" {
 module "apigateway" {
   source = "../../../../../modules/aws/apigateway"
 
+  vpc_id                     = local.vpc_id
+  subnet_private_ids         = local.subnet_private_ids
+  vpc_link_name              = local.vpc_link_name
+  sg_vpc_link_name           = local.sg_vpc_link_name
   apigateway_name            = local.apigateway_name
   apigateway_stage           = local.apigateway_stage
   authorizer_audience        = local.authorizer_audience
@@ -33,4 +39,6 @@ module "apigateway" {
   apigateway_domain_name     = local.apigateway_domain_name
   certificate_arn            = local.alb_certificate_arn
   zone_id                    = data.aws_route53_zone.api.zone_id
+  sg_internal_alb_id         = module.api.sg_internal_alb_id
+  internal_alb_listener_arn  = module.api.internal_alb_listener_arn
 }

--- a/providers/aws/environments/stg/20-api/variables.tf
+++ b/providers/aws/environments/stg/20-api/variables.tf
@@ -4,6 +4,8 @@ locals {
 
   api_alb_name                     = "${local.env}-${local.name}-api"
   sg_alb_name                      = "${local.env}-${local.name}-api-alb"
+  api_internal_alb_name            = "${local.env}-${local.name}-api-internal"
+  sg_internal_alb_name             = "${local.env}-${local.name}-api-internal-alb"
   alblogs_enabled                  = false
   sub_domain_name                  = "stg-api"
   ecs_cluster_name                 = "${local.env}-${local.name}"
@@ -25,6 +27,8 @@ locals {
 }
 
 locals {
+  vpc_link_name              = "${local.env}-${local.name}"
+  sg_vpc_link_name           = "${local.env}-${local.name}-vpc-link"
   apigateway_name            = "${local.env}-${local.name}-api"
   auto_deploy                = true
   integration_uri            = "https://${local.sub_domain_name}.${var.main_domain_name}"


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/kimono-app-terraform/issues/16

# Doneの定義
https://github.com/nekochans/kimono-app-terraform/issues/16 の完了の定義が満たされていること

# 変更点概要

## 技術的変更点概要
バックエンドAPI用にInternal ALBを作成。
API GatewayからVPCリンクを介して、InternalALB配下のFargateに接続するように変更した。

なお開発の都合上、API Gatewayを通さないで直接バックエンドのAPIを呼び出せるように、Public ALBは残してある。