### PR TITLE
Terraformのバージョンを0.13にアップグレードする

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.11
 
-ARG TERRAFORM_VERSION=0.12.24
+ARG TERRAFORM_VERSION=0.13.0
 
 RUN set -eux \
   && apk update\

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
       context: .
       dockerfile: Dockerfile
       args:
-        - TERRAFORM_VERSION=0.12.24
+        - TERRAFORM_VERSION=0.13.0
     tty: true
     volumes:
       - .:/data

--- a/modules/aws/apigateway/main.tf
+++ b/modules/aws/apigateway/main.tf
@@ -7,6 +7,10 @@ resource "aws_apigatewayv2_stage" "apigateway" {
   api_id      = aws_apigatewayv2_api.apigateway.id
   name        = var.apigateway_stage
   auto_deploy = var.auto_deploy
+
+  lifecycle {
+    ignore_changes = [deployment_id]
+  }
 }
 
 resource "aws_apigatewayv2_route" "apigateway" {
@@ -25,6 +29,10 @@ resource "aws_apigatewayv2_integration" "vpclink" {
   integration_type   = "HTTP_PROXY"
   integration_method = "ANY"
   integration_uri    = var.internal_alb_listener_arn
+
+  lifecycle {
+    ignore_changes = [passthrough_behavior]
+  }
 }
 
 resource "aws_apigatewayv2_authorizer" "apigateway" {

--- a/providers/aws/environments/prod/10-network/versions.tf
+++ b/providers/aws/environments/prod/10-network/versions.tf
@@ -1,7 +1,10 @@
 terraform {
-  required_version = "0.12.24"
+  required_version = ">= 0.13"
 
   required_providers {
-    aws = "2.57.0"
+    aws = {
+      source  = "hashicorp/aws"
+      version = "2.57.0"
+    }
   }
 }

--- a/providers/aws/environments/stg/10-network/main.tf
+++ b/providers/aws/environments/stg/10-network/main.tf
@@ -1,6 +1,6 @@
 module "vpc" {
   source  = "nekochans/vpc/aws"
-  version = "1.0.1"
+  version = "2.0.1"
 
   name                     = local.name
   env                      = local.env

--- a/providers/aws/environments/stg/10-network/versions.tf
+++ b/providers/aws/environments/stg/10-network/versions.tf
@@ -1,7 +1,10 @@
 terraform {
-  required_version = "0.12.24"
+  required_version = ">= 0.13"
 
   required_providers {
-    aws = "2.70.0"
+    aws = {
+      source  = "hashicorp/aws"
+      version = "2.70.0"
+    }
   }
 }

--- a/providers/aws/environments/stg/11-acm/versions.tf
+++ b/providers/aws/environments/stg/11-acm/versions.tf
@@ -1,7 +1,10 @@
 terraform {
-  required_version = "0.12.24"
+  required_version = ">= 0.13"
 
   required_providers {
-    aws = "2.70.0"
+    aws = {
+      source  = "hashicorp/aws"
+      version = "2.70.0"
+    }
   }
 }

--- a/providers/aws/environments/stg/12-ecr/versions.tf
+++ b/providers/aws/environments/stg/12-ecr/versions.tf
@@ -1,7 +1,10 @@
 terraform {
-  required_version = "0.12.24"
+  required_version = ">= 0.13"
 
   required_providers {
-    aws = "2.70.0"
+    aws = {
+      source  = "hashicorp/aws"
+      version = "2.70.0"
+    }
   }
 }

--- a/providers/aws/environments/stg/13-ses/versions.tf
+++ b/providers/aws/environments/stg/13-ses/versions.tf
@@ -1,7 +1,10 @@
 terraform {
-  required_version = "0.12.24"
+  required_version = ">= 0.13"
 
   required_providers {
-    aws = "2.70.0"
+    aws = {
+      source  = "hashicorp/aws"
+      version = "2.70.0"
+    }
   }
 }

--- a/providers/aws/environments/stg/14-cognito/versions.tf
+++ b/providers/aws/environments/stg/14-cognito/versions.tf
@@ -1,7 +1,10 @@
 terraform {
-  required_version = "0.12.24"
+  required_version = ">= 0.13"
 
   required_providers {
-    aws = "2.70.0"
+    aws = {
+      source  = "hashicorp/aws"
+      version = "2.70.0"
+    }
   }
 }

--- a/providers/aws/environments/stg/20-api/versions.tf
+++ b/providers/aws/environments/stg/20-api/versions.tf
@@ -1,7 +1,10 @@
 terraform {
-  required_version = "0.12.24"
+  required_version = ">= 0.13"
 
   required_providers {
-    aws = "2.70.0"
+    aws = {
+      source  = "hashicorp/aws"
+      version = "2.70.0"
+    }
   }
 }


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/kimono-app-terraform/issues/27

# 関連URL
Upgrading to Terraform v0.13 - Terraform by HashiCorp
https://www.terraform.io/upgrade-guides/0-13.html

# Doneの定義
https://github.com/nekochans/kimono-app-terraform/issues/27 の完了の定義が満たされていること

# 変更点概要

## 仕様的変更点概要
Terraformのバージョンを0.13にアップグレード

## 技術的変更点概要
- Docker環境をTerraform v0.13に変更

- terraform planで差分が出ないようにignore_changesを追加
    - aws_apigatewayv2_integration の passthrough_behaviorで差分が発生していたが、
Terraform AWS Providerの不具合であった。下記のPRで修正され、version 3.0.0で修正されている。
https://github.com/terraform-providers/terraform-provider-aws/pull/13062
今回はignore_changesを追加して対応

    - aws_apigatewayv2_stage の差分
auto_deployをtrueにしているので、deployment_idが差分として発生するのでignore_changesを追加して対応

- アップグレード手順は下記の記事にまとめた
https://qiita.com/kobayashi-m42/private/ff19b11a746ee6f3efa5