### PR TITLE
不要になったCustomScopeとリソースサーバーの設定を削除

### DIFF
--- a/.github/workflows/ci-master.yml
+++ b/.github/workflows/ci-master.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Setup Terraform
       uses: hashicorp/setup-terraform@v1
       with:
-        terraform_version: 0.12.24
+        terraform_version: 0.13.2
 
     - name: Terraform Format
       run: terraform fmt -recursive -check

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.11
 
-ARG TERRAFORM_VERSION=0.13.0
+ARG TERRAFORM_VERSION=0.13.2
 
 RUN set -eux \
   && apk update\

--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ tfenvとDockerの利用を紹介します。どちらを利用してもいいで
 
 その後以下の手順で設定を行います。
 
-- `tfenv install 0.12.24`
-- `tfenv use 0.12.24`
-- `terraform --version` で Terraform v0.12.24 が表示されればOK
+- `tfenv install 0.13.02`
+- `tfenv use 0.13.02`
+- `terraform --version` で Terraform v0.13.02 が表示されればOK
 
 #### Docker
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
       context: .
       dockerfile: Dockerfile
       args:
-        - TERRAFORM_VERSION=0.13.0
+        - TERRAFORM_VERSION=0.13.2
     tty: true
     volumes:
       - .:/data

--- a/modules/aws/cognito/main.tf
+++ b/modules/aws/cognito/main.tf
@@ -47,7 +47,7 @@ resource "aws_cognito_user_pool_client" "client" {
   generate_secret               = false
   prevent_user_existence_errors = "ENABLED"
   refresh_token_validity        = 30
-  explicit_auth_flows           = ["ALLOW_USER_PASSWORD_AUTH", "ALLOW_ADMIN_USER_PASSWORD_AUTH", "ALLOW_REFRESH_TOKEN_AUTH"]
+  explicit_auth_flows           = ["ALLOW_USER_SRP_AUTH", "ALLOW_USER_PASSWORD_AUTH", "ALLOW_ADMIN_USER_PASSWORD_AUTH", "ALLOW_REFRESH_TOKEN_AUTH"]
 
   allowed_oauth_flows_user_pool_client = true
   allowed_oauth_scopes                 = var.allowed_oauth_scopes
@@ -55,22 +55,6 @@ resource "aws_cognito_user_pool_client" "client" {
   supported_identity_providers         = ["COGNITO"]
   allowed_oauth_flows                  = ["code"]
 
-}
-
-resource "aws_cognito_resource_server" "resource" {
-  identifier = var.resource_server_identifier
-  name       = var.resource_server_name
-
-  scope {
-    scope_name        = "admin"
-    scope_description = "for administrator"
-  }
-  scope {
-    scope_name        = "normal"
-    scope_description = "for normal user"
-  }
-
-  user_pool_id = aws_cognito_user_pool.pool.id
 }
 
 resource "aws_cognito_user_pool_domain" "domain" {

--- a/providers/aws/environments/stg/14-cognito/variables.tf
+++ b/providers/aws/environments/stg/14-cognito/variables.tf
@@ -6,6 +6,6 @@ locals {
   user_pool_domain           = "${local.env}-${local.name}"
   resource_server_name       = "${local.env}-${local.name}"
   resource_server_identifier = "${local.env}-${local.name}"
-  allowed_oauth_scopes       = ["openid", "stg-kimono-app/admin", "stg-kimono-app/normal"]
+  allowed_oauth_scopes       = ["openid"]
   callback_urls              = ["http://localhost:3000"]
 }


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/kimono-app-terraform/issues/30

# Doneの定義
- https://github.com/nekochans/kimono-app-terraform/issues/30 の完了の定義にある通り、CustomScopeとリソースサーバーの設定が削除されている事

# 変更点概要

## 技術的変更点概要
- CustomScopeとリソースサーバー用のリソースを削除

PRの趣旨とは関係ないが、Terraformの0.13.2系がリリースされていたのでマイナーバージョンアップを実施。

GItHubActions上のバージョン指定が0.13になっていなかったのでここも変更してある。