### PR TITLE
メールアドレスとパスワードでログイン出来るようにUserPoolの設定を変更

### DIFF
--- a/modules/aws/cognito/main.tf
+++ b/modules/aws/cognito/main.tf
@@ -50,12 +50,12 @@ resource "aws_cognito_user_pool" "pool" {
 }
 
 resource "aws_cognito_user_pool_client" "client" {
-  name                          = var.user_pool_name
-  user_pool_id                  = aws_cognito_user_pool.pool.id
-  generate_secret               = false
-  prevent_user_existence_errors = "ENABLED"
-  refresh_token_validity        = 30
-  explicit_auth_flows           = ["ALLOW_USER_SRP_AUTH", "ALLOW_USER_PASSWORD_AUTH", "ALLOW_ADMIN_USER_PASSWORD_AUTH", "ALLOW_REFRESH_TOKEN_AUTH"]
+  name                                 = var.user_pool_name
+  user_pool_id                         = aws_cognito_user_pool.pool.id
+  generate_secret                      = false
+  prevent_user_existence_errors        = "ENABLED"
+  refresh_token_validity               = 30
+  explicit_auth_flows                  = ["ALLOW_USER_SRP_AUTH", "ALLOW_USER_PASSWORD_AUTH", "ALLOW_ADMIN_USER_PASSWORD_AUTH", "ALLOW_REFRESH_TOKEN_AUTH"]
   allowed_oauth_flows_user_pool_client = true
   allowed_oauth_scopes                 = var.allowed_oauth_scopes
   callback_urls                        = var.callback_urls

--- a/modules/aws/cognito/main.tf
+++ b/modules/aws/cognito/main.tf
@@ -6,6 +6,8 @@ resource "aws_cognito_user_pool" "pool" {
     allow_admin_create_user_only = false
   }
 
+  username_attributes = ["email", "phone_number"]
+
   password_policy {
     minimum_length                   = 8
     require_lowercase                = true
@@ -13,6 +15,12 @@ resource "aws_cognito_user_pool" "pool" {
     require_symbols                  = true
     require_uppercase                = true
     temporary_password_validity_days = 7
+  }
+
+  mfa_configuration = "OPTIONAL"
+
+  software_token_mfa_configuration {
+    enabled = true
   }
 
   verification_message_template {
@@ -48,13 +56,11 @@ resource "aws_cognito_user_pool_client" "client" {
   prevent_user_existence_errors = "ENABLED"
   refresh_token_validity        = 30
   explicit_auth_flows           = ["ALLOW_USER_SRP_AUTH", "ALLOW_USER_PASSWORD_AUTH", "ALLOW_ADMIN_USER_PASSWORD_AUTH", "ALLOW_REFRESH_TOKEN_AUTH"]
-
   allowed_oauth_flows_user_pool_client = true
   allowed_oauth_scopes                 = var.allowed_oauth_scopes
   callback_urls                        = var.callback_urls
   supported_identity_providers         = ["COGNITO"]
   allowed_oauth_flows                  = ["code"]
-
 }
 
 resource "aws_cognito_user_pool_domain" "domain" {


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/kimono-app-terraform/issues/34

# 関連URL
なし

# Doneの定義
- https://github.com/nekochans/kimono-app-terraform/issues/34 の完了の定義にあるようにメールアドレスとパスワードでログイン出来るようにUserPoolの設定が変更されている事

# 変更点概要

## 技術的変更点概要
- `aws_cognito_user_pool.username_attributes` に `email` と `phone_number` を設定

これによってメールアドレス、もしくは電話番号 + パスワードによる認証が可能になった。
電話番号に関しては今は使わないが将来的に利用する可能性があるので念の為設定した。（この項目を変更するとUserPoolを一度削除して作り直す必要が出てくる為）

![UserPool](https://user-images.githubusercontent.com/11032365/92748239-e8e75800-f3bf-11ea-9e33-ea41edc33b32.png)

このPRの趣旨とは関係ないが、MFAの設定を任意だが有効にしてある。

# 補足情報
`aws_cognito_user_pool.pool` は変更不可能な項目を変更したのでリソースの再作成が走っている。（再作成されたのはCognitoUserPoolだけ）

以下のディレクトリ配下で `terraform apply` を実行済。

- `providers/aws/environments/stg/14-cognito/`
- `providers/aws/environments/stg/20-api/`