### PR TITLE
kimono-app-apiのCI/CD用のIAMユーザを作成

### DIFF
--- a/modules/aws/cognito/outputs.tf
+++ b/modules/aws/cognito/outputs.tf
@@ -1,3 +1,7 @@
 output "cognito_user_pool_endpoint" {
   value = aws_cognito_user_pool.pool.endpoint
 }
+
+output "cognito_user_pool_arn" {
+  value = aws_cognito_user_pool.pool.arn
+}

--- a/modules/aws/iam/main.tf
+++ b/modules/aws/iam/main.tf
@@ -1,0 +1,34 @@
+resource "aws_iam_user" "api_deploy" {
+  name = var.api_deploy_user
+}
+
+resource "aws_iam_user_policy_attachment" "ecs" {
+  user       = aws_iam_user.api_deploy.id
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ContainerServiceFullAccess"
+}
+
+resource "aws_iam_user_policy_attachment" "ecr" {
+  user       = aws_iam_user.api_deploy.id
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryPowerUser"
+}
+
+resource "aws_iam_user_policy_attachment" "cognito" {
+  user       = aws_iam_user.api_deploy.id
+  policy_arn = aws_iam_policy.cognito.arn
+}
+
+resource "aws_iam_policy" "cognito" {
+  name   = "cognito_crate_test_user"
+  path   = "/"
+  policy = data.aws_iam_policy_document.cognito.json
+}
+
+data "aws_iam_policy_document" "cognito" {
+  statement {
+    effect = "Allow"
+    actions = [
+      "cognito-idp:AdminConfirmSignUp"
+    ]
+    resources = [var.cognito_arn]
+  }
+}

--- a/modules/aws/iam/variables.tf
+++ b/modules/aws/iam/variables.tf
@@ -1,0 +1,7 @@
+variable "api_deploy_user" {
+  type = string
+}
+
+variable "cognito_arn" {
+  type = string
+}

--- a/providers/aws/environments/stg/14-cognito/outputs.tf
+++ b/providers/aws/environments/stg/14-cognito/outputs.tf
@@ -1,3 +1,7 @@
 output "cognito_user_pool_endpoint" {
   value = module.api.cognito_user_pool_endpoint
 }
+
+output "cognito_user_pool_arn" {
+  value = module.api.cognito_user_pool_arn
+}

--- a/providers/aws/environments/stg/15-iam/backend.tf
+++ b/providers/aws/environments/stg/15-iam/backend.tf
@@ -1,0 +1,19 @@
+terraform {
+  backend "s3" {
+    bucket  = "stg-kimono-app-tfstate"
+    key     = "iam/terraform.tfstate"
+    region  = "ap-northeast-1"
+    profile = "kimono-app-stg"
+  }
+}
+
+data "terraform_remote_state" "cognito" {
+  backend = "s3"
+
+  config = {
+    bucket  = "stg-kimono-app-tfstate"
+    key     = "cognito/terraform.tfstate"
+    region  = "ap-northeast-1"
+    profile = "kimono-app-stg"
+  }
+}

--- a/providers/aws/environments/stg/15-iam/main.tf
+++ b/providers/aws/environments/stg/15-iam/main.tf
@@ -1,0 +1,6 @@
+module "iam" {
+  source = "../../../../../modules/aws/iam"
+
+  api_deploy_user = local.api_deploy_user
+  cognito_arn     = data.terraform_remote_state.cognito.outputs.cognito_user_pool_arn
+}

--- a/providers/aws/environments/stg/15-iam/provider.tf
+++ b/providers/aws/environments/stg/15-iam/provider.tf
@@ -1,0 +1,4 @@
+provider "aws" {
+  region  = "ap-northeast-1"
+  profile = "kimono-app-stg"
+}

--- a/providers/aws/environments/stg/15-iam/variables.tf
+++ b/providers/aws/environments/stg/15-iam/variables.tf
@@ -1,0 +1,5 @@
+locals {
+  name            = "kimono-app"
+  env             = "stg"
+  api_deploy_user = "${local.env}-${local.name}-api-deploy"
+}

--- a/providers/aws/environments/stg/15-iam/versions.tf
+++ b/providers/aws/environments/stg/15-iam/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 0.13"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "2.70.0"
+    }
+  }
+}


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/kimono-app-terraform/issues/39

# Doneの定義
https://github.com/nekochans/kimono-app-terraform/issues/39 の完了条件を満たしていること

# 変更点概要

## 技術的変更点概要
kimono-app-api の CI/CD 用のIAMユーザを作成。
下記のpolicyをアタッチした。
- CIに必要なCognitoUserを作成するためのポリシー
- CD(ECSデプロイ)に必要なECS/ECRのポリシー

なお、将来的にGitHubのSecretに登録している値をSSMパラメータストア などから取得する処理が必要になるかもしれないが、現時点では考慮しない。

[Amazon ECS 管理ポリシーと信頼関係](https://docs.aws.amazon.com/ja_jp/AmazonECS/latest/developerguide/ecs_managed_policies.html)
[Amazon ECR 管理ポリシー](https://docs.aws.amazon.com/ja_jp/AmazonECR/latest/userguide/ecr_managed_policies.html)