### PR TITLE
ローカル環境用のCognitoUserPoolを作成

### DIFF
--- a/.github/workflows/ci-master.yml
+++ b/.github/workflows/ci-master.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Setup Terraform
       uses: hashicorp/setup-terraform@v1
       with:
-        terraform_version: 0.13.2
+        terraform_version: 0.13.6
 
     - name: Terraform Format
       run: terraform fmt -recursive -check

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.11
 
-ARG TERRAFORM_VERSION=0.13.2
+ARG TERRAFORM_VERSION=0.13.6
 
 RUN set -eux \
   && apk update\

--- a/README.md
+++ b/README.md
@@ -104,6 +104,20 @@ terraform-boilerplate/
 
 今後このプロジェクトをベースに機能を追加する際も依存関係を意識してディレクトリ名を決める必要があります。
 
+### 環境変数
+
+数カ所 `terraform.tfvars` の設置が必要な箇所があります。（後に `terraform.tfvars` を自動生成する処理を追加します）
+
+設定が必要な変数は以下の通りです。
+
+```terraform
+// providers/aws/environments/○○/11-acm/terraform.tfvars
+main_domain_name = "Route53に設定されているドメイン名を指定"
+
+// providers/aws/environments/○○/13-ses/terraform.tfvars
+email_address = "送信元となるメールアドレスを指定、開発用途ならGmailのアドレス等で十分"
+```
+
 ## 設計方針
 
 - 今はAWSのみだが、他のproviderが増えても大丈夫なように `providers/` を作ってあります

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@
 
 tfenvとDockerの利用を紹介します。どちらを利用してもいいです。
 
+Dockerのほうが環境によって差異が出ないのでオススメです。
+
 #### tfenv
 
 詳細は[tfenv](https://github.com/Zordrak/tfenv/blob/master/README.md)を確認してください。
@@ -18,9 +20,9 @@ tfenvとDockerの利用を紹介します。どちらを利用してもいいで
 
 その後以下の手順で設定を行います。
 
-- `tfenv install 0.13.02`
-- `tfenv use 0.13.02`
-- `terraform --version` で Terraform v0.13.02 が表示されればOK
+- `tfenv install 0.13.06`
+- `tfenv use 0.13.06`
+- `terraform --version` で Terraform v0.13.06 が表示されればOK
 
 #### Docker
 

--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ terraform-boilerplate/
 
 ```terraform
 // providers/aws/environments/○○/11-acm/terraform.tfvars
+// providers/aws/environments/○○/20-api/terraform.tfvars
 main_domain_name = "Route53に設定されているドメイン名を指定"
 
 // providers/aws/environments/○○/13-ses/terraform.tfvars

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
       context: .
       dockerfile: Dockerfile
       args:
-        - TERRAFORM_VERSION=0.13.2
+        - TERRAFORM_VERSION=0.13.6
     tty: true
     volumes:
       - .:/data

--- a/modules/aws/cognito/main.tf
+++ b/modules/aws/cognito/main.tf
@@ -50,7 +50,7 @@ resource "aws_cognito_user_pool" "pool" {
 }
 
 resource "aws_cognito_user_pool_client" "kimono_app_frontend" {
-  name                                 = var.user_pool_name
+  name                                 = "kimono-app-frontend"
   user_pool_id                         = aws_cognito_user_pool.pool.id
   generate_secret                      = false
   prevent_user_existence_errors        = "ENABLED"

--- a/modules/aws/cognito/main.tf
+++ b/modules/aws/cognito/main.tf
@@ -55,7 +55,7 @@ resource "aws_cognito_user_pool_client" "kimono_app_frontend" {
   generate_secret                      = false
   prevent_user_existence_errors        = "ENABLED"
   refresh_token_validity               = 30
-  explicit_auth_flows                  = ["ALLOW_USER_SRP_AUTH", "ALLOW_USER_PASSWORD_AUTH", "ALLOW_ADMIN_USER_PASSWORD_AUTH", "ALLOW_REFRESH_TOKEN_AUTH"]
+  explicit_auth_flows                  = ["ALLOW_USER_SRP_AUTH", "ALLOW_REFRESH_TOKEN_AUTH", "ALLOW_CUSTOM_AUTH"]
   allowed_oauth_flows_user_pool_client = true
   allowed_oauth_scopes                 = var.allowed_oauth_scopes
   callback_urls                        = var.callback_urls

--- a/modules/aws/cognito/main.tf
+++ b/modules/aws/cognito/main.tf
@@ -49,7 +49,7 @@ resource "aws_cognito_user_pool" "pool" {
   }
 }
 
-resource "aws_cognito_user_pool_client" "client" {
+resource "aws_cognito_user_pool_client" "kimono_app_frontend" {
   name                                 = var.user_pool_name
   user_pool_id                         = aws_cognito_user_pool.pool.id
   generate_secret                      = false

--- a/modules/aws/cognito/outputs.tf
+++ b/modules/aws/cognito/outputs.tf
@@ -5,3 +5,7 @@ output "cognito_user_pool_endpoint" {
 output "cognito_user_pool_arn" {
   value = aws_cognito_user_pool.pool.arn
 }
+
+output "kimono_app_frontend_client_id" {
+  value = aws_cognito_user_pool_client.client.id
+}

--- a/modules/aws/cognito/outputs.tf
+++ b/modules/aws/cognito/outputs.tf
@@ -7,5 +7,5 @@ output "cognito_user_pool_arn" {
 }
 
 output "kimono_app_frontend_client_id" {
-  value = aws_cognito_user_pool_client.client.id
+  value = aws_cognito_user_pool_client.kimono_app_frontend.id
 }

--- a/providers/aws/environments/local/13-ses/backend.tf
+++ b/providers/aws/environments/local/13-ses/backend.tf
@@ -1,0 +1,8 @@
+terraform {
+  backend "s3" {
+    bucket  = "local-kimono-app-tfstate"
+    key     = "ses/terraform.tfstate"
+    region  = "ap-northeast-1"
+    profile = "kimono-app-stg"
+  }
+}

--- a/providers/aws/environments/local/13-ses/main.tf
+++ b/providers/aws/environments/local/13-ses/main.tf
@@ -1,0 +1,9 @@
+module "ses" {
+  source = "../../../../../modules/aws/ses"
+
+  email_address = var.email_address
+
+  providers = {
+    aws = aws.us-east-1
+  }
+}

--- a/providers/aws/environments/local/13-ses/outputs.tf
+++ b/providers/aws/environments/local/13-ses/outputs.tf
@@ -1,0 +1,3 @@
+output "ses_email_identity_arn" {
+  value = module.ses.ses_email_identity_arn
+}

--- a/providers/aws/environments/local/13-ses/provider.tf
+++ b/providers/aws/environments/local/13-ses/provider.tf
@@ -1,0 +1,10 @@
+provider "aws" {
+  region  = "ap-northeast-1"
+  profile = "kimono-app-stg"
+}
+
+provider "aws" {
+  region  = "us-east-1"
+  profile = "kimono-app-stg"
+  alias   = "us-east-1"
+}

--- a/providers/aws/environments/local/13-ses/variables.tf
+++ b/providers/aws/environments/local/13-ses/variables.tf
@@ -1,0 +1,9 @@
+locals {
+  name = "kimono-app"
+  env  = "local"
+}
+
+variable "email_address" {
+  type    = string
+  default = ""
+}

--- a/providers/aws/environments/local/13-ses/versions.tf
+++ b/providers/aws/environments/local/13-ses/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 0.13"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "2.70.0"
+    }
+  }
+}

--- a/providers/aws/environments/local/14-cognito/backend.tf
+++ b/providers/aws/environments/local/14-cognito/backend.tf
@@ -1,0 +1,19 @@
+terraform {
+  backend "s3" {
+    bucket  = "local-kimono-app-tfstate"
+    key     = "cognito/terraform.tfstate"
+    region  = "ap-northeast-1"
+    profile = "kimono-app-stg"
+  }
+}
+
+data "terraform_remote_state" "ses" {
+  backend = "s3"
+
+  config = {
+    bucket  = "local-kimono-app-tfstate"
+    key     = "ses/terraform.tfstate"
+    region  = "ap-northeast-1"
+    profile = "kimono-app-stg"
+  }
+}

--- a/providers/aws/environments/local/14-cognito/main.tf
+++ b/providers/aws/environments/local/14-cognito/main.tf
@@ -1,0 +1,11 @@
+module "cognito" {
+  source = "../../../../../modules/aws/cognito"
+
+  user_pool_name             = local.user_pool_name
+  user_pool_domain           = local.user_pool_domain
+  resource_server_name       = local.resource_server_name
+  resource_server_identifier = local.resource_server_identifier
+  ses_email_identity_arn     = data.terraform_remote_state.ses.outputs.ses_email_identity_arn
+  allowed_oauth_scopes       = local.allowed_oauth_scopes
+  callback_urls              = local.callback_urls
+}

--- a/providers/aws/environments/local/14-cognito/outputs.tf
+++ b/providers/aws/environments/local/14-cognito/outputs.tf
@@ -1,0 +1,7 @@
+output "cognito_user_pool_endpoint" {
+  value = module.cognito.cognito_user_pool_endpoint
+}
+
+output "cognito_user_pool_arn" {
+  value = module.cognito.cognito_user_pool_arn
+}

--- a/providers/aws/environments/local/14-cognito/provider.tf
+++ b/providers/aws/environments/local/14-cognito/provider.tf
@@ -1,0 +1,4 @@
+provider "aws" {
+  region  = "ap-northeast-1"
+  profile = "kimono-app-stg"
+}

--- a/providers/aws/environments/local/14-cognito/variables.tf
+++ b/providers/aws/environments/local/14-cognito/variables.tf
@@ -1,0 +1,11 @@
+locals {
+  name = "kimono-app"
+  env  = "local"
+
+  user_pool_name             = "${local.env}-${local.name}"
+  user_pool_domain           = "${local.env}-${local.name}"
+  resource_server_name       = "${local.env}-${local.name}"
+  resource_server_identifier = "${local.env}-${local.name}"
+  allowed_oauth_scopes       = ["openid"]
+  callback_urls              = ["http://localhost:3100"]
+}

--- a/providers/aws/environments/local/14-cognito/versions.tf
+++ b/providers/aws/environments/local/14-cognito/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 0.13"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "2.70.0"
+    }
+  }
+}

--- a/providers/aws/environments/stg/14-cognito/main.tf
+++ b/providers/aws/environments/stg/14-cognito/main.tf
@@ -1,4 +1,4 @@
-module "api" {
+module "cognito" {
   source = "../../../../../modules/aws/cognito"
 
   user_pool_name             = local.user_pool_name

--- a/providers/aws/environments/stg/14-cognito/outputs.tf
+++ b/providers/aws/environments/stg/14-cognito/outputs.tf
@@ -5,3 +5,7 @@ output "cognito_user_pool_endpoint" {
 output "cognito_user_pool_arn" {
   value = module.api.cognito_user_pool_arn
 }
+
+output "kimono_app_frontend_client_id" {
+  value = module.api.kimono_app_frontend_client_id
+}

--- a/providers/aws/environments/stg/14-cognito/outputs.tf
+++ b/providers/aws/environments/stg/14-cognito/outputs.tf
@@ -1,11 +1,11 @@
 output "cognito_user_pool_endpoint" {
-  value = module.api.cognito_user_pool_endpoint
+  value = module.cognito.cognito_user_pool_endpoint
 }
 
 output "cognito_user_pool_arn" {
-  value = module.api.cognito_user_pool_arn
+  value = module.cognito.cognito_user_pool_arn
 }
 
 output "kimono_app_frontend_client_id" {
-  value = module.api.kimono_app_frontend_client_id
+  value = module.cognito.kimono_app_frontend_client_id
 }

--- a/providers/aws/environments/stg/14-cognito/variables.tf
+++ b/providers/aws/environments/stg/14-cognito/variables.tf
@@ -7,5 +7,5 @@ locals {
   resource_server_name       = "${local.env}-${local.name}"
   resource_server_identifier = "${local.env}-${local.name}"
   allowed_oauth_scopes       = ["openid"]
-  callback_urls              = ["http://localhost:3000"]
+  callback_urls              = ["https://kimono-app.net"]
 }

--- a/providers/aws/environments/stg/14-cognito/variables.tf
+++ b/providers/aws/environments/stg/14-cognito/variables.tf
@@ -7,5 +7,5 @@ locals {
   resource_server_name       = "${local.env}-${local.name}"
   resource_server_identifier = "${local.env}-${local.name}"
   allowed_oauth_scopes       = ["openid"]
-  callback_urls              = ["https://kimono-app.net"]
+  callback_urls              = ["https://stg.kimono-app.net"]
 }

--- a/providers/aws/environments/stg/20-api/variables.tf
+++ b/providers/aws/environments/stg/20-api/variables.tf
@@ -34,7 +34,7 @@ locals {
   integration_uri            = "https://${local.sub_domain_name}.${var.main_domain_name}"
   apigateway_domain_name     = "stg-apigateway.${var.main_domain_name}"
   apigateway_stage           = "$default"
-  authorizer_audience        = [var.cognito_user_pool_client_id]
+  authorizer_audience        = [data.terraform_remote_state.cognito.outputs.kimono_app_frontend_client_id]
   cognito_user_pool_endpoint = "https://${data.terraform_remote_state.cognito.outputs.cognito_user_pool_endpoint}"
 }
 
@@ -43,12 +43,6 @@ variable "main_domain_name" {
   default = ""
 }
 
-variable "cognito_user_pool_client_id" {
-  type    = string
-  default = ""
-}
-
 data "aws_route53_zone" "api" {
   name = var.main_domain_name
 }
-


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/kimono-app-terraform/issues/43

# Doneの定義
- ローカル環境用のCognitoUserPoolが作成されている事
- 既存のCognitoUserPoolはステージング環境用に設定が変更されている事

# 変更点概要

## 技術的変更点概要
`providers/aws/environments/local/` ディレクトリを作成し、ローカル用の設定を追加。

また、既存のCognitoUserPoolをステージング用の設定とする為に、リソース名の変更等を行っている。

※ その関係でCognitoUserPoolの再作成を行っている。

また、いくつか軽微なリファクタリングを行っているが、それはコードのインラインコメントに記載してある。