### PR TITLE
kimono-app-frontend用のVercelとの連携用レコードを作成

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ terraform-boilerplate/
 ```terraform
 // providers/aws/environments/○○/11-acm/terraform.tfvars
 // providers/aws/environments/○○/20-api/terraform.tfvars
+// providers/aws/environments/○○/21-frontend/terraform.tfvars
 main_domain_name = "Route53に設定されているドメイン名を指定"
 
 // providers/aws/environments/○○/13-ses/terraform.tfvars

--- a/modules/aws/frontend/main.tf
+++ b/modules/aws/frontend/main.tf
@@ -1,0 +1,9 @@
+resource "aws_route53_record" "frontend" {
+  zone_id = var.zone_id
+  name    = var.sub_domain_name
+  type    = "CNAME"
+
+  ttl = "5"
+
+  records = [var.vercel_cname_value]
+}

--- a/modules/aws/frontend/variables.tf
+++ b/modules/aws/frontend/variables.tf
@@ -1,0 +1,11 @@
+variable "zone_id" {
+  type = string
+}
+
+variable "sub_domain_name" {
+  type = string
+}
+
+variable "vercel_cname_value" {
+  type = string
+}

--- a/providers/aws/environments/stg/21-frontend/.terraform.lock.hcl
+++ b/providers/aws/environments/stg/21-frontend/.terraform.lock.hcl
@@ -1,0 +1,22 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "2.70.0"
+  constraints = "2.70.0"
+  hashes = [
+    "h1:6tf4jg37RrMHyVCql+fEgAFvX8JiqDognr+lk6rx7To=",
+    "zh:01a5f351146434b418f9ff8d8cc956ddc801110f1cc8b139e01be2ff8c544605",
+    "zh:1ec08abbaf09e3e0547511d48f77a1e2c89face2d55886b23f643011c76cb247",
+    "zh:606d134fef7c1357c9d155aadbee6826bc22bc0115b6291d483bc1444291c3e1",
+    "zh:67e31a71a5ecbbc96a1a6708c9cc300bbfe921c322320cdbb95b9002026387e1",
+    "zh:75aa59ae6f0834ed7142c81569182a658e4c22724a34db5d10f7545857d8db0c",
+    "zh:76880f29fca7a0a3ff1caef31d245af2fb12a40709d67262e099bc22d039a51d",
+    "zh:aaeaf97ffc1f76714e68bc0242c7407484c783d604584c04ad0b267b6812b6dc",
+    "zh:ae1f88d19cc85b2e9b6ef71994134d55ef7830fd02f1f3c58c0b3f2b90e8b337",
+    "zh:b155bdda487461e7b3d6e3a8d5ce5c887a047e4d983512e81e2c8266009f2a1f",
+    "zh:ba394a7c391a26c4a91da63ad680e83bde0bc1ecc0a0856e26e9d62a4e77c408",
+    "zh:e243c9d91feb0979638f28eb26f89ebadc179c57a2bd299b5729fb52bd1902f2",
+    "zh:f6c05e20d9a3fba76ca5f47206dde35e5b43b6821c6cbf57186164ce27ba9f15",
+  ]
+}

--- a/providers/aws/environments/stg/21-frontend/backend.tf
+++ b/providers/aws/environments/stg/21-frontend/backend.tf
@@ -1,0 +1,8 @@
+terraform {
+  backend "s3" {
+    bucket  = "stg-kimono-app-tfstate"
+    key     = "frontend/terraform.tfstate"
+    region  = "ap-northeast-1"
+    profile = "kimono-app-stg"
+  }
+}

--- a/providers/aws/environments/stg/21-frontend/main.tf
+++ b/providers/aws/environments/stg/21-frontend/main.tf
@@ -1,0 +1,7 @@
+module "frontend" {
+  source = "../../../../../modules/aws/frontend"
+
+  zone_id            = local.zone_id
+  sub_domain_name    = local.sub_domain_name
+  vercel_cname_value = local.vercel_cname_value
+}

--- a/providers/aws/environments/stg/21-frontend/provider.tf
+++ b/providers/aws/environments/stg/21-frontend/provider.tf
@@ -1,0 +1,4 @@
+provider "aws" {
+  region  = "ap-northeast-1"
+  profile = "kimono-app-stg"
+}

--- a/providers/aws/environments/stg/21-frontend/variables.tf
+++ b/providers/aws/environments/stg/21-frontend/variables.tf
@@ -1,0 +1,15 @@
+locals {
+  env                = "stg"
+  sub_domain_name    = local.env
+  zone_id            = data.aws_route53_zone.frontend.zone_id
+  vercel_cname_value = "cname.vercel-dns.com"
+}
+
+variable "main_domain_name" {
+  type    = string
+  default = ""
+}
+
+data "aws_route53_zone" "frontend" {
+  name = var.main_domain_name
+}

--- a/providers/aws/environments/stg/21-frontend/versions.tf
+++ b/providers/aws/environments/stg/21-frontend/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 0.14"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "2.70.0"
+    }
+  }
+}


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/kimono-app-terraform/issues/47

# 関連URL
https://stg.kimono-app.net/

# Doneの定義
- `kimono-app-frontend` が独自ドメインでアクセスされている事

# 変更点概要

## 技術的変更点概要
- フロントエンド用のディレクトリ `providers/aws/environments/stg/21-frontend/` を作成
- Vercelとの連携に必要なCNAMEレコードを追加

# 補足情報
やった事はまさにこのブログの内容そのまま。

https://dev.classmethod.jp/articles/vercel-custom-domain-route53/
